### PR TITLE
What module?

### DIFF
--- a/lib/sequel-honeycomb.rb
+++ b/lib/sequel-honeycomb.rb
@@ -4,4 +4,9 @@ begin
   require 'sequel/honeycomb'
 rescue Gem::LoadError
   warn 'sequel not detected, not enabling sequel-honeycomb'
+
+  # some gems use the presence of the Sequel module to determine if Sequel is in
+  # use by the application. If we can't require the gem then we need to remove
+  # the constant that we define so that other gems don't make bad assumptions
+  Object.send(:remove_const, "Sequel")
 end


### PR DESCRIPTION
Some other gems use the presence of the Sequel module that we define to
detect if the Sequel gem is in use and attempt to configure themselves
based on that. This causes them to break so we remove our defined module
if we fail to detect the Sequel gem 😬

Here is at least one example where this is done https://github.com/algolia/algoliasearch-rails/blob/25436b69de166b60eb220890e2eb8a07ed65ac82/lib/algoliasearch-rails.rb#L401

I'm not convinced this is the best approach to solve this, open to any other thoughts