### PR TITLE
Cross-process tracing changes

### DIFF
--- a/lib/honeycomb/version.rb
+++ b/lib/honeycomb/version.rb
@@ -1,4 +1,0 @@
-module Honeycomb
-  GEM_NAME = 'honeycomb'
-  VERSION = '0.0.1'
-end

--- a/lib/sequel/extensions/honeycomb.rb
+++ b/lib/sequel/extensions/honeycomb.rb
@@ -21,6 +21,7 @@ module Sequel
           @builder ||= @client.builder.add(
             'meta.package' => 'sequel',
             'meta.package_version' => Sequel::VERSION,
+            'type' => 'db',
           )
         end
 
@@ -39,8 +40,9 @@ module Sequel
 
         event.add_field 'db.table', first_source_table.to_s rescue nil
         event.add_field 'db.sql', sql
+        event.add_field 'name', query_name(sql)
         start = Time.now
-        with_tracing_if_available(event, query_name(sql)) do
+        with_tracing_if_available(event) do
           super
         end
       rescue Exception => e
@@ -63,10 +65,27 @@ module Sequel
         sql.sub(/\s+.*/, '').upcase
       end
 
-      def with_tracing_if_available(event, name)
-        return yield unless defined?(::Honeycomb::Beeline::VERSION)
+      def with_tracing_if_available(event)
+        # return if we are not using the ruby beeline
+        return yield unless defined?(::Honeycomb)
 
-        ::Honeycomb.span_for_existing_event(event, name: name, type: 'db') do
+        # beeline version <= 0.5.0
+        if ::Honeycomb.respond_to? :trace_id
+          trace_id = ::Honeycomb.trace_id
+          event.add_field 'trace.trace_id', trace_id if trace_id
+          span_id = SecureRandom.uuid
+          event.add_field 'trace.span_id', span_id
+          ::Honeycomb.with_span_id(span_id) do |parent_span_id|
+            event.add_field 'trace.parent_id', parent_span_id
+            yield
+          end
+        # beeline version > 0.5.0
+        elsif ::Honeycomb.respond_to? :span_for_existing_event
+          ::Honeycomb.span_for_existing_event(event, name: nil, type: 'db') do
+            yield
+          end
+        # fallback if we don't detect any known beeline tracing methods
+        else
           yield
         end
       end

--- a/spec/extensions/honeycomb_extension_spec.rb
+++ b/spec/extensions/honeycomb_extension_spec.rb
@@ -3,6 +3,14 @@ require 'support/fakehoney'
 require 'sequel/extensions/honeycomb'
 
 RSpec.shared_examples_for 'records a database query' do |name:, sql_match:, sql_not_match: nil|
+  it 'sends a db event' do
+    expect(last_event.data['type']).to eq('db')
+  end
+
+  it "sets 'name' to #{name.inspect} (although something more informative would be nicer!)" do
+    expect(last_event.data['name']).to eq(name)
+  end
+
   it 'records the SQL query' do
     expect(last_event.data).to include('db.sql' => sql_match)
   end


### PR DESCRIPTION
Adding some changes to #1 that would be good to get some separate 👀  on. Was able to add the removed tests back in as we now continue to support stand alone usage of this gem. Also removed a redundant version file which creates the `Honeycomb` module that we use to initially detect the beeline, it looks to be unused