### PR TITLE
Also remove Sequel constant here

### DIFF
--- a/lib/sequel-honeycomb/auto_install.rb
+++ b/lib/sequel-honeycomb/auto_install.rb
@@ -8,6 +8,10 @@ module Sequel
           true
         rescue Gem::LoadError => e
           logger.debug "Didn't detect Sequel (#{e.class}: #{e.message}), not autoinitialising sequel-honeycomb" if logger
+          # some gems use the presence of the Sequel module to determine if Sequel is in
+          # use by the application. If we can't require the gem then we need to remove
+          # the constant that we define so that other gems don't make bad assumptions
+          Object.send(:remove_const, "Sequel")
           false
         end
 


### PR DESCRIPTION
Although we remove the Sequel constant when the gem is required, the
beeline still calls auto_install which recreates the Sequel constant at
a later time. Depending on initialization timing of other gems that look
for the Sequel constant still don't work