### PR TITLE
[WIP] Only define the module if required

### DIFF
--- a/lib/sequel-honeycomb.rb
+++ b/lib/sequel-honeycomb.rb
@@ -4,9 +4,4 @@ begin
   require 'sequel/honeycomb'
 rescue Gem::LoadError
   warn 'sequel not detected, not enabling sequel-honeycomb'
-
-  # some gems use the presence of the Sequel module to determine if Sequel is in
-  # use by the application. If we can't require the gem then we need to remove
-  # the constant that we define so that other gems don't make bad assumptions
-  Object.send(:remove_const, "Sequel")
 end

--- a/lib/sequel-honeycomb/auto_install.rb
+++ b/lib/sequel-honeycomb/auto_install.rb
@@ -1,24 +1,25 @@
-module Sequel
-  module Honeycomb
-    module AutoInstall
-      class << self
-        def available?(logger: nil)
-          gem 'sequel'
-          logger.debug "#{self.name}: detected sequel, okay to autoinitialise" if logger
-          true
-        rescue Gem::LoadError => e
-          logger.debug "Didn't detect Sequel (#{e.class}: #{e.message}), not autoinitialising sequel-honeycomb" if logger
-          # some gems use the presence of the Sequel module to determine if Sequel is in
-          # use by the application. If we can't require the gem then we need to remove
-          # the constant that we define so that other gems don't make bad assumptions
-          Object.send(:remove_const, "Sequel")
-          false
-        end
+# only define this module if the Sequel constant is already defined (by way of
+# having the sequel gem installed) or if this gem has been included by an older
+# version of the beeline which is not able to handle this module not existing
+if (defined? Sequel) || (Gem::Version.new(Honeycomb::Beeline::VERSION) <= Gem::Version.new("0.6.0"))
+  module Sequel
+    module Honeycomb
+      module AutoInstall
+        class << self
+          def available?(logger: nil)
+            gem 'sequel'
+            logger.debug "#{self.name}: detected sequel, okay to autoinitialise" if logger
+            true
+          rescue Gem::LoadError => e
+            logger.debug "Didn't detect Sequel (#{e.class}: #{e.message}), not autoinitialising sequel-honeycomb" if logger
+            false
+          end
 
-        def auto_install!(honeycomb_client:, logger: nil)
-          require 'sequel/honeycomb'
+          def auto_install!(honeycomb_client:, logger: nil)
+            require 'sequel/honeycomb'
 
-          Sequel::Honeycomb.install!(client: honeycomb_client, logger: logger)
+            Sequel::Honeycomb.install!(client: honeycomb_client, logger: logger)
+          end
         end
       end
     end


### PR DESCRIPTION
Rather than removing the constant we need to not define it in the first place if we can. This requires support from the beeline as it currently always expects these modules to exist. 

https://github.com/honeycombio/beeline-ruby/pull/6